### PR TITLE
hull tech

### DIFF
--- a/StarsCoreEngine/starscoreengine/template_tech.py
+++ b/StarsCoreEngine/starscoreengine/template_tech.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
     This file is part of Stars Core Engine, which provides an interface and 
     processing of Stars data. 
@@ -980,3 +982,19 @@ def order_tech():
         if not found:
             raise ValueError("Trying to apply a restriction to tech '{}' but it wasn't found in tech".format(k1))
     return tech
+
+def hull_slots(hullDatabase):
+    hullDicts = {}
+    for k, v in hullDatabase.items():
+        name = k
+        hullDict = {}
+        slotNames = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        letterNum = 0
+        for k2, v2 in v.items():
+            if v2: #skip empty types of slots
+                for i in v2:
+                    hullDict[slotNames[letterNum]] = {"objectType": k2, "slotsAvalable": i}
+                    letterNum += 1
+        hullDicts[k] = hullDict
+    return hullDicts
+    

--- a/StarsCoreEngine/tests/test_tech.py
+++ b/StarsCoreEngine/tests/test_tech.py
@@ -36,3 +36,40 @@ class TestTech(unittest.TestCase):
         self.assertNotEqual(tech["shields"]["Croby Sharmor"], {"energy" : 7, "weapons" : 0, "propulsion" : 0, "construction" : 4, 
                                                             "electronics" : 0, "biotechnology" : 0, "mass" : 10, "resources" : 15, 
                                                             "iron" : 7, "bor" : 0, "germ" : 4, "shieldDP" : 60, "hasPRT" : ["SS"], "hasLRT" : [], "notLRT" : []})
+
+    def test_hulls(self):
+            tmp =  {"Battleship" : {"Armor" : [6],
+                            "Armor Scanner Elect/Mech" : [],
+                            "Bomb" : [],
+                            "Elect" : [3, 3],
+                            "Engine" : [4],
+                            "General Purpose" : [],
+                            "Mech" : [],
+                            "Mine" : [],
+                            "Mine Elect Mech" : [],
+                            "Mining" : [],
+                            "Scanner" : [],
+                            "Scanner Elect Mech" : [1],
+                            "Shield" : [8],
+                            "Shield Elect Mech": [],
+                            "Shield or Armor" : [],
+                            "Weapon" : [2, 2, 6, 6, 4]}
+            }
+            hullDicts = hull_slots(tmp)
+            expectedDict = {'A': {'slotsAvalable': 4, 'objectType': 'Engine'}, 
+                            'B': {'slotsAvalable': 6, 'objectType': 'Armor'}, 
+                            'C': {'slotsAvalable': 2, 'objectType': 'Weapon'}, 
+                            'D': {'slotsAvalable': 2, 'objectType': 'Weapon'},              
+                            'E': {'slotsAvalable': 6, 'objectType': 'Weapon'}, 
+                            'F': {'slotsAvalable': 6, 'objectType': 'Weapon'}, 
+                            'G': {'slotsAvalable': 4, 'objectType': 'Weapon'}, 
+                            'H': {'slotsAvalable': 8, 'objectType': 'Shield'}, 
+                            'I': {'slotsAvalable': 3, 'objectType': 'Elect'}, 
+                            'J': {'slotsAvalable': 3, 'objectType': 'Elect'},
+                            'K': {'slotsAvalable': 1, 'objectType': 'Scanner Elect Mech'}
+                        }
+
+            self.assertEqual(hullDicts["Battleship"], expectedDict)
+
+
+


### PR DESCRIPTION
I've created a function to convert the dict of lists containing slot details to the dict used in the Hull class, and a test_function as an example of how it would be used to convert them.

How do you think the keys for this dict ('A', 'B' etc) will be used? 
